### PR TITLE
Feat/event filtration

### DIFF
--- a/TickAPI/TickAPI.Tests/Events/Services/EventFilterTests.cs
+++ b/TickAPI/TickAPI.Tests/Events/Services/EventFilterTests.cs
@@ -8,8 +8,6 @@ namespace TickAPI.Tests.Events.Services;
 
 public class EventFilterTests
 {
-    private readonly EventFilter _eventFilter = new EventFilter();
-
     private static List<Event> GetTestEvents() =>
     [
         new Event
@@ -103,7 +101,9 @@ public class EventFilterTests
         var events = GetTestEvents();
 
         // Act
-        var result = _eventFilter.FilterByName(events.AsQueryable(), "concert").ToList();
+        var eventFilter = new EventFilter(events.AsQueryable());
+        eventFilter.FilterByName("concert");
+        var result = eventFilter.GetEvents().ToList();
 
         // Assert
         Assert.Equal(2, result.Count);
@@ -118,7 +118,9 @@ public class EventFilterTests
         var events = GetTestEvents();
 
         // Act
-        var result = _eventFilter.FilterByDescription(events.AsQueryable(), "tech").ToList();
+        var eventFilter = new EventFilter(events.AsQueryable());
+        eventFilter.FilterByDescription("tech");
+        var result = eventFilter.GetEvents().ToList();
 
         // Assert
         Assert.Single(result);
@@ -132,7 +134,9 @@ public class EventFilterTests
         var events = GetTestEvents();
 
         // Act
-        var result = _eventFilter.FilterByStartDate(events.AsQueryable(), new DateTime(2025, 5, 1)).ToList();
+        var eventFilter = new EventFilter(events.AsQueryable());
+        eventFilter.FilterByStartDate(new DateTime(2025, 5, 1));
+        var result = eventFilter.GetEvents().ToList();
 
         // Assert
         Assert.Equal(2, result.Count);
@@ -147,7 +151,9 @@ public class EventFilterTests
         var events = GetTestEvents();
 
         // Act
-        var result = _eventFilter.FilterByEndDate(events.AsQueryable(), new DateTime(2025, 5, 1, 22, 0, 0)).ToList();
+        var eventFilter = new EventFilter(events.AsQueryable());
+        eventFilter.FilterByEndDate(new DateTime(2025, 5, 1, 22, 0, 0));
+        var result = eventFilter.GetEvents().ToList();
 
         // Assert
         Assert.Single(result);
@@ -161,7 +167,9 @@ public class EventFilterTests
         var events = GetTestEvents();
 
         // Act
-        var result = _eventFilter.FilterByMinPrice(events.AsQueryable(), 100).ToList();
+        var eventFilter = new EventFilter(events.AsQueryable());
+        eventFilter.FilterByMinPrice(100);
+        var result = eventFilter.GetEvents().ToList();
 
         // Assert
         Assert.Equal(2, result.Count);
@@ -176,7 +184,9 @@ public class EventFilterTests
         var events = GetTestEvents();
 
         // Act
-        var result = _eventFilter.FilterByMaxPrice(events.AsQueryable(), 100).ToList();
+        var eventFilter = new EventFilter(events.AsQueryable());
+        eventFilter.FilterByMaxPrice(100);
+        var result = eventFilter.GetEvents().ToList();
 
         // Assert
         Assert.Single(result);
@@ -190,7 +200,9 @@ public class EventFilterTests
         var events = GetTestEvents();
 
         // Act
-        var result = _eventFilter.FilterByMinAge(events.AsQueryable(), 18).ToList();
+        var eventFilter = new EventFilter(events.AsQueryable());
+        eventFilter.FilterByMinAge(18);
+        var result = eventFilter.GetEvents().ToList();
 
         // Assert
         Assert.Equal(2, result.Count);
@@ -205,7 +217,9 @@ public class EventFilterTests
         var events = GetTestEvents();
 
         // Act
-        var result = _eventFilter.FilterByMaxAge(events.AsQueryable(), 18).ToList();
+        var eventFilter = new EventFilter(events.AsQueryable());
+        eventFilter.FilterByMaxAge(18);
+        var result = eventFilter.GetEvents().ToList();
 
         // Assert
         Assert.Equal(2, result.Count);
@@ -220,7 +234,9 @@ public class EventFilterTests
         var events = GetTestEvents();
 
         // Act
-        var result = _eventFilter.FilterByAddressCountry(events.AsQueryable(), "poland").ToList();
+        var eventFilter = new EventFilter(events.AsQueryable());
+        eventFilter.FilterByAddressCountry("poland");
+        var result = eventFilter.GetEvents().ToList();
 
         // Assert
         Assert.Equal(2, result.Count);
@@ -235,7 +251,9 @@ public class EventFilterTests
         var events = GetTestEvents();
 
         // Act
-        var result = _eventFilter.FilterByAddressCity(events.AsQueryable(), "berlin").ToList();
+        var eventFilter = new EventFilter(events.AsQueryable());
+        eventFilter.FilterByAddressCity("berlin");
+        var result = eventFilter.GetEvents().ToList();
 
         // Assert
         Assert.Single(result);
@@ -249,7 +267,9 @@ public class EventFilterTests
         var events = GetTestEvents();
 
         // Act
-        var result = _eventFilter.FilterByAddressStreet(events.AsQueryable(), "marszałkowska", 12, 5).ToList();
+        var eventFilter = new EventFilter(events.AsQueryable());
+        eventFilter.FilterByAddressStreet("marszałkowska", 12, 5);
+        var result = eventFilter.GetEvents().ToList();
 
         // Assert
         Assert.Single(result);
@@ -263,7 +283,9 @@ public class EventFilterTests
         var events = GetTestEvents();
 
         // Act
-        var result = _eventFilter.FilterByAddressStreet(events.AsQueryable(), "marszałkowska", 12).ToList();
+        var eventFilter = new EventFilter(events.AsQueryable());
+        eventFilter.FilterByAddressStreet("marszałkowska", 12);
+        var result = eventFilter.GetEvents().ToList();
 
         // Assert
         Assert.Single(result);
@@ -277,7 +299,9 @@ public class EventFilterTests
         var events = GetTestEvents();
 
         // Act
-        var result = _eventFilter.FilterByAddressStreet(events.AsQueryable(), "długa").ToList();
+        var eventFilter = new EventFilter(events.AsQueryable());
+        eventFilter.FilterByAddressStreet("długa");
+        var result = eventFilter.GetEvents().ToList();
 
         // Assert
         Assert.Single(result);
@@ -291,7 +315,9 @@ public class EventFilterTests
         var events = GetTestEvents();
 
         // Act
-        var result = _eventFilter.FilterByAddressPostalCode(events.AsQueryable(), "10117").ToList();
+        var eventFilter = new EventFilter(events.AsQueryable());
+        eventFilter.FilterByAddressPostalCode("10117");
+        var result = eventFilter.GetEvents().ToList();
 
         // Assert
         Assert.Single(result);
@@ -305,7 +331,9 @@ public class EventFilterTests
         var events = GetTestEvents();
 
         // Act
-        var result = _eventFilter.FilterByCategoriesNames(events.AsQueryable(), ["Jazz", "Technology"]).ToList();
+        var eventFilter = new EventFilter(events.AsQueryable());
+        eventFilter.FilterByCategoriesNames(["Jazz", "Technology"]);
+        var result = eventFilter.GetEvents().ToList();
 
         // Assert
         Assert.Equal(2, result.Count);

--- a/TickAPI/TickAPI.Tests/Events/Services/EventFilterTests.cs
+++ b/TickAPI/TickAPI.Tests/Events/Services/EventFilterTests.cs
@@ -145,6 +145,39 @@ public class EventFilterTests
     }
     
     [Fact]
+    public void FilterByMinStartDate_ShouldReturnMatchingEvents()
+    {
+        // Arrange
+        var events = GetTestEvents();
+
+        // Act
+        var eventFilter = new EventFilter(events.AsQueryable());
+        eventFilter.FilterByMinStartDate(new DateTime(2025, 5, 15));
+        var result = eventFilter.GetEvents().ToList();
+
+        // Assert
+        Assert.Single(result);
+        Assert.Contains(events[1], result);
+    }
+    
+    [Fact]
+    public void FilterByMaxStartDate_ShouldReturnMatchingEvents()
+    {
+        // Arrange
+        var events = GetTestEvents();
+
+        // Act
+        var eventFilter = new EventFilter(events.AsQueryable());
+        eventFilter.FilterByMaxStartDate(new DateTime(2025, 5, 15));
+        var result = eventFilter.GetEvents().ToList();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Contains(events[0], result);
+        Assert.Contains(events[2], result);
+    }
+    
+    [Fact]
     public void FilterByEndDate_ShouldReturnMatchingEvents()
     {
         // Arrange
@@ -158,6 +191,39 @@ public class EventFilterTests
         // Assert
         Assert.Single(result);
         Assert.Contains(events[0], result);
+    }
+    
+    [Fact]
+    public void FilterByMinEndDate_ShouldReturnMatchingEvents()
+    {
+        // Arrange
+        var events = GetTestEvents();
+
+        // Act
+        var eventFilter = new EventFilter(events.AsQueryable());
+        eventFilter.FilterByMinEndDate(new DateTime(2025, 5, 15));
+        var result = eventFilter.GetEvents().ToList();
+
+        // Assert
+        Assert.Single(result);
+        Assert.Contains(events[1], result);
+    }
+    
+    [Fact]
+    public void FilterByMaxEndDate_ShouldReturnMatchingEvents()
+    {
+        // Arrange
+        var events = GetTestEvents();
+
+        // Act
+        var eventFilter = new EventFilter(events.AsQueryable());
+        eventFilter.FilterByMaxEndDate(new DateTime(2025, 5, 15));
+        var result = eventFilter.GetEvents().ToList();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Contains(events[0], result);
+        Assert.Contains(events[2], result);
     }
     
     [Fact]

--- a/TickAPI/TickAPI.Tests/Events/Services/EventFilterTests.cs
+++ b/TickAPI/TickAPI.Tests/Events/Services/EventFilterTests.cs
@@ -1,4 +1,5 @@
-﻿using TickAPI.Events.Models;
+﻿using TickAPI.Addresses.Models;
+using TickAPI.Events.Models;
 using TickAPI.Events.Services;
 using TickAPI.TicketTypes.Models;
 
@@ -17,6 +18,15 @@ public class EventFilterTests
             StartDate = new DateTime(2025, 5, 1, 18, 0, 0),
             EndDate = new DateTime(2025, 5, 1, 22, 0, 0),
             MinimumAge = 18,
+            Address = new Address
+            {
+                Country = "Poland",
+                City = "Warsaw",
+                Street = "Marszałkowska",
+                HouseNumber = 12,
+                FlatNumber = 5,
+                PostalCode = "00-001"
+            },
             TicketTypes = new List<TicketType>
             {
                 new TicketType { Price = 100 },
@@ -31,6 +41,15 @@ public class EventFilterTests
             StartDate = new DateTime(2025, 6, 1),
             EndDate = new DateTime(2025, 6, 2),
             MinimumAge = 12,
+            Address = new Address
+            {
+                Country = "Germany",
+                City = "Berlin",
+                Street = "Unter den Linden",
+                HouseNumber = 44,
+                FlatNumber = 10,
+                PostalCode = "10117"
+            },
             TicketTypes = new List<TicketType>
             {
                 new TicketType { Price = 50 }
@@ -44,6 +63,15 @@ public class EventFilterTests
             StartDate = new DateTime(2025, 5, 1),
             EndDate = new DateTime(2025, 5, 3),
             MinimumAge = 21,
+            Address = new Address
+            {
+                Country = "Poland",
+                City = "Krakow",
+                Street = "Długa",
+                HouseNumber = 7,
+                FlatNumber = 3,
+                PostalCode = "31-147"
+            },
             TicketTypes = new List<TicketType>
             {
                 new TicketType { Price = 200 },
@@ -168,4 +196,90 @@ public class EventFilterTests
         Assert.Contains(events[0], result);
         Assert.Contains(events[1], result);
     }
+    
+    [Fact]
+    public void FilterByAddressCountry_ShouldReturnMatchingEvents()
+    {
+        // Arrange
+        var events = GetTestEvents();
+
+        // Act
+        var result = _eventFilter.FilterByAddressCountry(events.AsQueryable(), "poland").ToList();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Contains(events[0], result);
+        Assert.Contains(events[2], result);
+    }
+
+    [Fact]
+    public void FilterByAddressCity_ShouldReturnMatchingEvents()
+    {
+        // Arrange
+        var events = GetTestEvents();
+
+        // Act
+        var result = _eventFilter.FilterByAddressCity(events.AsQueryable(), "berlin").ToList();
+
+        // Assert
+        Assert.Single(result);
+        Assert.Contains(events[1], result);
+    }
+
+    [Fact]
+    public void FilterByAddressStreet_WithAllParameters_ShouldReturnMatchingEvents()
+    {
+        // Arrange
+        var events = GetTestEvents();
+
+        // Act
+        var result = _eventFilter.FilterByAddressStreet(events.AsQueryable(), "marszałkowska", 12, 5).ToList();
+
+        // Assert
+        Assert.Single(result);
+        Assert.Contains(events[0], result);
+    }
+
+    [Fact]
+    public void FilterByAddressStreet_WithoutFlatNumber_ShouldReturnMatchingEvents()
+    {
+        // Arrange
+        var events = GetTestEvents();
+
+        // Act
+        var result = _eventFilter.FilterByAddressStreet(events.AsQueryable(), "marszałkowska", 12).ToList();
+
+        // Assert
+        Assert.Single(result);
+        Assert.Contains(events[0], result);
+    }
+
+    [Fact]
+    public void FilterByAddressStreet_WithStreetOnly_ShouldReturnMatchingEvents()
+    {
+        // Arrange
+        var events = GetTestEvents();
+
+        // Act
+        var result = _eventFilter.FilterByAddressStreet(events.AsQueryable(), "długa").ToList();
+
+        // Assert
+        Assert.Single(result);
+        Assert.Contains(events[2], result);
+    }
+
+    [Fact]
+    public void FilterByAddressPostalCode_ShouldReturnMatchingEvents()
+    {
+        // Arrange
+        var events = GetTestEvents();
+
+        // Act
+        var result = _eventFilter.FilterByAddressPostalCode(events.AsQueryable(), "10117").ToList();
+
+        // Assert
+        Assert.Single(result);
+        Assert.Contains(events[1], result);
+    }
+
 }

--- a/TickAPI/TickAPI.Tests/Events/Services/EventFilterTests.cs
+++ b/TickAPI/TickAPI.Tests/Events/Services/EventFilterTests.cs
@@ -1,4 +1,5 @@
 ﻿using TickAPI.Addresses.Models;
+using TickAPI.Categories.Models;
 using TickAPI.Events.Models;
 using TickAPI.Events.Services;
 using TickAPI.TicketTypes.Models;
@@ -31,6 +32,11 @@ public class EventFilterTests
             {
                 new TicketType { Price = 100 },
                 new TicketType { Price = 120 }
+            },
+            Categories = new List<Category>
+            {
+                new Category { Name = "Music" },
+                new Category { Name = "Rock" }
             }
         },
 
@@ -53,6 +59,11 @@ public class EventFilterTests
             TicketTypes = new List<TicketType>
             {
                 new TicketType { Price = 50 }
+            },
+            Categories = new List<Category>
+            {
+                new Category { Name = "Music" },
+                new Category { Name = "Jazz" }
             }
         },
 
@@ -76,6 +87,11 @@ public class EventFilterTests
             {
                 new TicketType { Price = 200 },
                 new TicketType { Price = 150 }
+            },
+            Categories = new List<Category>
+            {
+                new Category { Name = "Technology" },
+                new Category { Name = "Development" }
             }
         }
     ];
@@ -280,6 +296,21 @@ public class EventFilterTests
         // Assert
         Assert.Single(result);
         Assert.Contains(events[1], result);
+    }
+
+    [Fact]
+    public void FilterByCategoriesNames_ShouldReturnMatchingEvents()
+    {
+        // Arrange
+        var events = GetTestEvents();
+
+        // Act
+        var result = _eventFilter.FilterByCategoriesNames(events.AsQueryable(), ["Jazz", "Technology"]).ToList();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Contains(events[1], result);
+        Assert.Contains(events[2], result);
     }
 
 }

--- a/TickAPI/TickAPI.Tests/Events/Services/EventFilterTests.cs
+++ b/TickAPI/TickAPI.Tests/Events/Services/EventFilterTests.cs
@@ -255,7 +255,8 @@ public class EventFilterTests
         var result = eventFilter.GetEvents().ToList();
 
         // Assert
-        Assert.Single(result);
+        Assert.Equal(2, result.Count);
+        Assert.Contains(events[0], result);
         Assert.Contains(events[1], result);
     }
     
@@ -277,14 +278,14 @@ public class EventFilterTests
     }
 
     [Fact]
-    public void FilterByMaxAge_ShouldReturnMatchingEvents()
+    public void FilterByMaxMinimumAge_ShouldReturnMatchingEvents()
     {
         // Arrange
         var events = GetTestEvents();
 
         // Act
         var eventFilter = new EventFilter(events.AsQueryable());
-        eventFilter.FilterByMaxAge(18);
+        eventFilter.FilterByMaxMinimumAge(18);
         var result = eventFilter.GetEvents().ToList();
 
         // Assert

--- a/TickAPI/TickAPI.Tests/Events/Services/EventFilterTests.cs
+++ b/TickAPI/TickAPI.Tests/Events/Services/EventFilterTests.cs
@@ -1,0 +1,171 @@
+﻿using TickAPI.Events.Models;
+using TickAPI.Events.Services;
+using TickAPI.TicketTypes.Models;
+
+namespace TickAPI.Tests.Events.Services;
+
+public class EventFilterTests
+{
+    private readonly EventFilter _eventFilter = new EventFilter();
+
+    private static List<Event> GetTestEvents() =>
+    [
+        new Event
+        {
+            Name = "Concert A",
+            Description = "An amazing rock concert",
+            StartDate = new DateTime(2025, 5, 1, 18, 0, 0),
+            EndDate = new DateTime(2025, 5, 1, 22, 0, 0),
+            MinimumAge = 18,
+            TicketTypes = new List<TicketType>
+            {
+                new TicketType { Price = 100 },
+                new TicketType { Price = 120 }
+            }
+        },
+
+        new Event
+        {
+            Name = "Concert B",
+            Description = "Chill jazz night",
+            StartDate = new DateTime(2025, 6, 1),
+            EndDate = new DateTime(2025, 6, 2),
+            MinimumAge = 12,
+            TicketTypes = new List<TicketType>
+            {
+                new TicketType { Price = 50 }
+            }
+        },
+
+        new Event
+        {
+            Name = "Conference",
+            Description = "Tech event for developers",
+            StartDate = new DateTime(2025, 5, 1),
+            EndDate = new DateTime(2025, 5, 3),
+            MinimumAge = 21,
+            TicketTypes = new List<TicketType>
+            {
+                new TicketType { Price = 200 },
+                new TicketType { Price = 150 }
+            }
+        }
+    ];
+
+    [Fact]
+    public void FilterByName_ShouldReturnMatchingEvents()
+    {
+        // Arrange
+        var events = GetTestEvents();
+
+        // Act
+        var result = _eventFilter.FilterByName(events.AsQueryable(), "concert").ToList();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Contains(events[0], result);
+        Assert.Contains(events[1], result);
+    }
+    
+    [Fact]
+    public void FilterByDescription_ShouldReturnMatchingEvents()
+    {
+        // Arrange
+        var events = GetTestEvents();
+
+        // Act
+        var result = _eventFilter.FilterByDescription(events.AsQueryable(), "tech").ToList();
+
+        // Assert
+        Assert.Single(result);
+        Assert.Contains(events[2], result);
+    }
+    
+    [Fact]
+    public void FilterByStartDate_ShouldReturnMatchingEvents()
+    {
+        // Arrange
+        var events = GetTestEvents();
+
+        // Act
+        var result = _eventFilter.FilterByStartDate(events.AsQueryable(), new DateTime(2025, 5, 1)).ToList();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Contains(events[0], result);
+        Assert.Contains(events[2], result);
+    }
+    
+    [Fact]
+    public void FilterByEndDate_ShouldReturnMatchingEvents()
+    {
+        // Arrange
+        var events = GetTestEvents();
+
+        // Act
+        var result = _eventFilter.FilterByEndDate(events.AsQueryable(), new DateTime(2025, 5, 1, 22, 0, 0)).ToList();
+
+        // Assert
+        Assert.Single(result);
+        Assert.Contains(events[0], result);
+    }
+    
+    [Fact]
+    public void FilterByMinPrice_ShouldReturnMatchingEvents()
+    {
+        // Arrange
+        var events = GetTestEvents();
+
+        // Act
+        var result = _eventFilter.FilterByMinPrice(events.AsQueryable(), 100).ToList();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Contains(events[0], result);
+        Assert.Contains(events[2], result);
+    }
+
+    [Fact]
+    public void FilterByMaxPrice_ShouldReturnMatchingEvents()
+    {
+        // Arrange
+        var events = GetTestEvents();
+
+        // Act
+        var result = _eventFilter.FilterByMaxPrice(events.AsQueryable(), 100).ToList();
+
+        // Assert
+        Assert.Single(result);
+        Assert.Contains(events[1], result);
+    }
+    
+    [Fact]
+    public void FilterByMinAge_ShouldReturnMatchingEvents()
+    {
+        // Arrange
+        var events = GetTestEvents();
+
+        // Act
+        var result = _eventFilter.FilterByMinAge(events.AsQueryable(), 18).ToList();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Contains(events[0], result);
+        Assert.Contains(events[2], result);
+    }
+
+    [Fact]
+    public void FilterByMaxAge_ShouldReturnMatchingEvents()
+    {
+        // Arrange
+        var events = GetTestEvents();
+
+        // Act
+        var result = _eventFilter.FilterByMaxAge(events.AsQueryable(), 18).ToList();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Contains(events[0], result);
+        Assert.Contains(events[1], result);
+    }
+}

--- a/TickAPI/TickAPI/Addresses/Models/Address.cs
+++ b/TickAPI/TickAPI/Addresses/Models/Address.cs
@@ -1,5 +1,4 @@
 ﻿namespace TickAPI.Addresses.Models;
-using TickAPI.Events.DTOs.Request;
 public class Address
 {
     public Guid Id { get; set; }

--- a/TickAPI/TickAPI/Events/Abstractions/IEventFilter.cs
+++ b/TickAPI/TickAPI/Events/Abstractions/IEventFilter.cs
@@ -16,6 +16,5 @@ public interface IEventFilter
     IQueryable<Event> FilterByAddressCity(IQueryable<Event> events, string city);
     IQueryable<Event> FilterByAddressStreet(IQueryable<Event> events, string street, uint? houseNumber, uint? flatNumber);
     IQueryable<Event> FilterByAddressPostalCode(IQueryable<Event> events, string postalCode);
-
-    // TODO: add filters for address and categories
+    IQueryable<Event> FilterByCategoriesNames(IQueryable<Event> events, IEnumerable<string> categoriesNames);
 }

--- a/TickAPI/TickAPI/Events/Abstractions/IEventFilter.cs
+++ b/TickAPI/TickAPI/Events/Abstractions/IEventFilter.cs
@@ -12,5 +12,10 @@ public interface IEventFilter
     IQueryable<Event> FilterByMaxPrice(IQueryable<Event> events, decimal maxPrice);
     IQueryable<Event> FilterByMinAge(IQueryable<Event> events, uint minAge);
     IQueryable<Event> FilterByMaxAge(IQueryable<Event> events, uint maxAge);
+    IQueryable<Event> FilterByAddressCountry(IQueryable<Event> events, string country);
+    IQueryable<Event> FilterByAddressCity(IQueryable<Event> events, string city);
+    IQueryable<Event> FilterByAddressStreet(IQueryable<Event> events, string street, uint? houseNumber, uint? flatNumber);
+    IQueryable<Event> FilterByAddressPostalCode(IQueryable<Event> events, string postalCode);
+
     // TODO: add filters for address and categories
 }

--- a/TickAPI/TickAPI/Events/Abstractions/IEventFilter.cs
+++ b/TickAPI/TickAPI/Events/Abstractions/IEventFilter.cs
@@ -1,0 +1,16 @@
+﻿using TickAPI.Events.Models;
+
+namespace TickAPI.Events.Abstractions;
+
+public interface IEventFilter
+{
+    IQueryable<Event> FilterByName(IQueryable<Event> events, string name);
+    IQueryable<Event> FilterByDescription(IQueryable<Event> events, string description);
+    IQueryable<Event> FilterByStartDate(IQueryable<Event> events, DateTime startDate);
+    IQueryable<Event> FilterByEndDate(IQueryable<Event> events, DateTime endDate);
+    IQueryable<Event> FilterByMinPrice(IQueryable<Event> events, decimal minPrice);
+    IQueryable<Event> FilterByMaxPrice(IQueryable<Event> events, decimal maxPrice);
+    IQueryable<Event> FilterByMinAge(IQueryable<Event> events, uint minAge);
+    IQueryable<Event> FilterByMaxAge(IQueryable<Event> events, uint maxAge);
+    // TODO: add filters for address and categories
+}

--- a/TickAPI/TickAPI/Events/Abstractions/IEventFilter.cs
+++ b/TickAPI/TickAPI/Events/Abstractions/IEventFilter.cs
@@ -8,7 +8,11 @@ public interface IEventFilter
     void FilterByName(string name);
     void FilterByDescription(string description);
     void FilterByStartDate(DateTime startDate);
+    void FilterByMinStartDate(DateTime startDate);
+    void FilterByMaxStartDate(DateTime startDate);
     void FilterByEndDate(DateTime endDate);
+    void FilterByMinEndDate(DateTime endDate);
+    void FilterByMaxEndDate(DateTime endDate);
     void FilterByMinPrice(decimal minPrice);
     void FilterByMaxPrice(decimal maxPrice);
     void FilterByMinAge(uint minAge);

--- a/TickAPI/TickAPI/Events/Abstractions/IEventFilter.cs
+++ b/TickAPI/TickAPI/Events/Abstractions/IEventFilter.cs
@@ -4,17 +4,18 @@ namespace TickAPI.Events.Abstractions;
 
 public interface IEventFilter
 {
-    IQueryable<Event> FilterByName(IQueryable<Event> events, string name);
-    IQueryable<Event> FilterByDescription(IQueryable<Event> events, string description);
-    IQueryable<Event> FilterByStartDate(IQueryable<Event> events, DateTime startDate);
-    IQueryable<Event> FilterByEndDate(IQueryable<Event> events, DateTime endDate);
-    IQueryable<Event> FilterByMinPrice(IQueryable<Event> events, decimal minPrice);
-    IQueryable<Event> FilterByMaxPrice(IQueryable<Event> events, decimal maxPrice);
-    IQueryable<Event> FilterByMinAge(IQueryable<Event> events, uint minAge);
-    IQueryable<Event> FilterByMaxAge(IQueryable<Event> events, uint maxAge);
-    IQueryable<Event> FilterByAddressCountry(IQueryable<Event> events, string country);
-    IQueryable<Event> FilterByAddressCity(IQueryable<Event> events, string city);
-    IQueryable<Event> FilterByAddressStreet(IQueryable<Event> events, string street, uint? houseNumber, uint? flatNumber);
-    IQueryable<Event> FilterByAddressPostalCode(IQueryable<Event> events, string postalCode);
-    IQueryable<Event> FilterByCategoriesNames(IQueryable<Event> events, IEnumerable<string> categoriesNames);
+    IQueryable<Event> GetEvents();
+    void FilterByName(string name);
+    void FilterByDescription(string description);
+    void FilterByStartDate(DateTime startDate);
+    void FilterByEndDate(DateTime endDate);
+    void FilterByMinPrice(decimal minPrice);
+    void FilterByMaxPrice(decimal maxPrice);
+    void FilterByMinAge(uint minAge);
+    void FilterByMaxAge(uint maxAge);
+    void FilterByAddressCountry(string country);
+    void FilterByAddressCity(string city);
+    void FilterByAddressStreet(string street, uint? houseNumber, uint? flatNumber);
+    void FilterByAddressPostalCode(string postalCode);
+    void FilterByCategoriesNames(IEnumerable<string> categoriesNames);
 }

--- a/TickAPI/TickAPI/Events/Abstractions/IEventFilter.cs
+++ b/TickAPI/TickAPI/Events/Abstractions/IEventFilter.cs
@@ -16,7 +16,7 @@ public interface IEventFilter
     void FilterByMinPrice(decimal minPrice);
     void FilterByMaxPrice(decimal maxPrice);
     void FilterByMinAge(uint minAge);
-    void FilterByMaxAge(uint maxAge);
+    void FilterByMaxMinimumAge(uint maxMinimumAge);
     void FilterByAddressCountry(string country);
     void FilterByAddressCity(string city);
     void FilterByAddressStreet(string street, uint? houseNumber, uint? flatNumber);

--- a/TickAPI/TickAPI/Events/Services/EventFilter.cs
+++ b/TickAPI/TickAPI/Events/Services/EventFilter.cs
@@ -1,0 +1,49 @@
+﻿using TickAPI.Events.Abstractions;
+using TickAPI.Events.Models;
+
+namespace TickAPI.Events.Services;
+
+public class EventFilter : IEventFilter
+{
+
+    public IQueryable<Event> FilterByName(IQueryable<Event> events, string name)
+    {
+        return events.Where(e => e.Name.Contains(name, StringComparison.CurrentCultureIgnoreCase));
+    }
+
+    public IQueryable<Event> FilterByDescription(IQueryable<Event> events, string description)
+    
+    {
+        return events.Where(e => e.Description.Contains(description, StringComparison.CurrentCultureIgnoreCase));
+    }
+
+    public IQueryable<Event> FilterByStartDate(IQueryable<Event> events, DateTime startDate)
+    {
+        return events.Where(e => e.StartDate.Date == startDate.Date);
+    }
+
+    public IQueryable<Event> FilterByEndDate(IQueryable<Event> events, DateTime endDate)
+    {
+        return events.Where(e => e.EndDate.Date == endDate.Date);
+    }
+
+    public IQueryable<Event> FilterByMinPrice(IQueryable<Event> events, decimal minPrice)
+    {
+        return events.Where(e => e.TicketTypes.All(t => t.Price >= minPrice));
+    }
+
+    public IQueryable<Event> FilterByMaxPrice(IQueryable<Event> events, decimal maxPrice)
+    {
+        return events.Where(e => e.TicketTypes.All(t => t.Price <= maxPrice));
+    }
+
+    public IQueryable<Event> FilterByMinAge(IQueryable<Event> events, uint minAge)
+    {
+        return events.Where(e => e.MinimumAge >= minAge);
+    }
+
+    public IQueryable<Event> FilterByMaxAge(IQueryable<Event> events, uint maxAge)
+    {
+        return events.Where(e => e.MinimumAge <= maxAge);
+    }
+}

--- a/TickAPI/TickAPI/Events/Services/EventFilter.cs
+++ b/TickAPI/TickAPI/Events/Services/EventFilter.cs
@@ -5,60 +5,72 @@ namespace TickAPI.Events.Services;
 
 public class EventFilter : IEventFilter
 {
-    public IQueryable<Event> FilterByName(IQueryable<Event> events, string name)
+    private IQueryable<Event> _events;
+
+    public EventFilter(IQueryable<Event> events)
     {
-        return events.Where(e => e.Name.Contains(name, StringComparison.CurrentCultureIgnoreCase));
+        _events = events;
     }
 
-    public IQueryable<Event> FilterByDescription(IQueryable<Event> events, string description)
+    public IQueryable<Event> GetEvents() 
+    {
+        return _events;
+    }
+
+    public void FilterByName(string name)
+    {
+        _events = _events.Where(e => e.Name.Contains(name, StringComparison.CurrentCultureIgnoreCase));
+    }
+
+    public void FilterByDescription(string description)
     
     {
-        return events.Where(e => e.Description.Contains(description, StringComparison.CurrentCultureIgnoreCase));
+        _events = _events.Where(e => e.Description.Contains(description, StringComparison.CurrentCultureIgnoreCase));
     }
 
-    public IQueryable<Event> FilterByStartDate(IQueryable<Event> events, DateTime startDate)
+    public void FilterByStartDate(DateTime startDate)
     {
-        return events.Where(e => e.StartDate.Date == startDate.Date);
+        _events = _events.Where(e => e.StartDate.Date == startDate.Date);
     }
 
-    public IQueryable<Event> FilterByEndDate(IQueryable<Event> events, DateTime endDate)
+    public void FilterByEndDate(DateTime endDate)
     {
-        return events.Where(e => e.EndDate.Date == endDate.Date);
+        _events = _events.Where(e => e.EndDate.Date == endDate.Date);
     }
 
-    public IQueryable<Event> FilterByMinPrice(IQueryable<Event> events, decimal minPrice)
+    public void FilterByMinPrice(decimal minPrice)
     {
-        return events.Where(e => e.TicketTypes.All(t => t.Price >= minPrice));
+        _events = _events.Where(e => e.TicketTypes.All(t => t.Price >= minPrice));
     }
 
-    public IQueryable<Event> FilterByMaxPrice(IQueryable<Event> events, decimal maxPrice)
+    public void FilterByMaxPrice(decimal maxPrice)
     {
-        return events.Where(e => e.TicketTypes.All(t => t.Price <= maxPrice));
+        _events = _events.Where(e => e.TicketTypes.All(t => t.Price <= maxPrice));
     }
 
-    public IQueryable<Event> FilterByMinAge(IQueryable<Event> events, uint minAge)
+    public void FilterByMinAge(uint minAge)
     {
-        return events.Where(e => e.MinimumAge >= minAge);
+        _events = _events.Where(e => e.MinimumAge >= minAge);
     }
 
-    public IQueryable<Event> FilterByMaxAge(IQueryable<Event> events, uint maxAge)
+    public void FilterByMaxAge(uint maxAge)
     {
-        return events.Where(e => e.MinimumAge <= maxAge);
+        _events = _events.Where(e => e.MinimumAge <= maxAge);
     }
 
-    public IQueryable<Event> FilterByAddressCountry(IQueryable<Event> events, string country)
+    public void FilterByAddressCountry(string country)
     {
-        return events.Where(e => e.Address.Country.Contains(country, StringComparison.CurrentCultureIgnoreCase));
+        _events = _events.Where(e => e.Address.Country.Contains(country, StringComparison.CurrentCultureIgnoreCase));
     }
 
-    public IQueryable<Event> FilterByAddressCity(IQueryable<Event> events, string city)
+    public void FilterByAddressCity(string city)
     {
-        return events.Where(e => e.Address.City.Contains(city, StringComparison.CurrentCultureIgnoreCase));
+        _events = _events.Where(e => e.Address.City.Contains(city, StringComparison.CurrentCultureIgnoreCase));
     }
 
-    public IQueryable<Event> FilterByAddressStreet(IQueryable<Event> events, string street, uint? houseNumber = null, uint? flatNumber = null)
+    public void FilterByAddressStreet(string street, uint? houseNumber = null, uint? flatNumber = null)
     {
-        var result = events.Where(e => e.Address.Street != null && e.Address.Street.Contains(street, StringComparison.CurrentCultureIgnoreCase));
+        var result = _events.Where(e => e.Address.Street != null && e.Address.Street.Contains(street, StringComparison.CurrentCultureIgnoreCase));
         if (houseNumber != null)
         {
             result = result.Where(e => e.Address.HouseNumber != null && e.Address.HouseNumber == houseNumber);
@@ -67,16 +79,16 @@ public class EventFilter : IEventFilter
         {
             result = result.Where(e => e.Address.FlatNumber != null && e.Address.FlatNumber == flatNumber);
         }
-        return result;
+        _events = result;
     }
 
-    public IQueryable<Event> FilterByAddressPostalCode(IQueryable<Event> events, string postalCode)
+    public void FilterByAddressPostalCode(string postalCode)
     {
-        return events.Where(e => e.Address.PostalCode == postalCode);
+        _events = _events.Where(e => e.Address.PostalCode == postalCode);
     }
 
-    public IQueryable<Event> FilterByCategoriesNames(IQueryable<Event> events, IEnumerable<string> categoriesNames)
+    public void FilterByCategoriesNames(IEnumerable<string> categoriesNames)
     {
-        return events.Where(e => e.Categories.Any(c => categoriesNames.Contains(c.Name)));
+        _events = _events.Where(e => e.Categories.Any(c => categoriesNames.Contains(c.Name)));
     }
 }

--- a/TickAPI/TickAPI/Events/Services/EventFilter.cs
+++ b/TickAPI/TickAPI/Events/Services/EventFilter.cs
@@ -32,9 +32,29 @@ public class EventFilter : IEventFilter
         _events = _events.Where(e => e.StartDate.Date == startDate.Date);
     }
 
+    public void FilterByMinStartDate(DateTime startDate)
+    {
+        _events = _events.Where(e => e.StartDate.Date >= startDate.Date);
+    }
+
+    public void FilterByMaxStartDate(DateTime startDate)
+    {
+        _events = _events.Where(e => e.StartDate.Date <= startDate.Date);
+    }
+
     public void FilterByEndDate(DateTime endDate)
     {
         _events = _events.Where(e => e.EndDate.Date == endDate.Date);
+    }
+
+    public void FilterByMinEndDate(DateTime endDate)
+    {
+        _events = _events.Where(e => e.EndDate.Date >= endDate.Date);
+    }
+
+    public void FilterByMaxEndDate(DateTime endDate)
+    {
+        _events = _events.Where(e => e.EndDate.Date <= endDate.Date);
     }
 
     public void FilterByMinPrice(decimal minPrice)

--- a/TickAPI/TickAPI/Events/Services/EventFilter.cs
+++ b/TickAPI/TickAPI/Events/Services/EventFilter.cs
@@ -5,7 +5,6 @@ namespace TickAPI.Events.Services;
 
 public class EventFilter : IEventFilter
 {
-
     public IQueryable<Event> FilterByName(IQueryable<Event> events, string name)
     {
         return events.Where(e => e.Name.Contains(name, StringComparison.CurrentCultureIgnoreCase));
@@ -45,5 +44,34 @@ public class EventFilter : IEventFilter
     public IQueryable<Event> FilterByMaxAge(IQueryable<Event> events, uint maxAge)
     {
         return events.Where(e => e.MinimumAge <= maxAge);
+    }
+
+    public IQueryable<Event> FilterByAddressCountry(IQueryable<Event> events, string country)
+    {
+        return events.Where(e => e.Address.Country.Contains(country, StringComparison.CurrentCultureIgnoreCase));
+    }
+
+    public IQueryable<Event> FilterByAddressCity(IQueryable<Event> events, string city)
+    {
+        return events.Where(e => e.Address.City.Contains(city, StringComparison.CurrentCultureIgnoreCase));
+    }
+
+    public IQueryable<Event> FilterByAddressStreet(IQueryable<Event> events, string street, uint? houseNumber = null, uint? flatNumber = null)
+    {
+        var result = events.Where(e => e.Address.Street != null && e.Address.Street.Contains(street, StringComparison.CurrentCultureIgnoreCase));
+        if (houseNumber != null)
+        {
+            result = result.Where(e => e.Address.HouseNumber != null && e.Address.HouseNumber == houseNumber);
+        }
+        if (flatNumber != null)
+        {
+            result = result.Where(e => e.Address.FlatNumber != null && e.Address.FlatNumber == flatNumber);
+        }
+        return result;
+    }
+
+    public IQueryable<Event> FilterByAddressPostalCode(IQueryable<Event> events, string postalCode)
+    {
+        return events.Where(e => e.Address.PostalCode == postalCode);
     }
 }

--- a/TickAPI/TickAPI/Events/Services/EventFilter.cs
+++ b/TickAPI/TickAPI/Events/Services/EventFilter.cs
@@ -59,12 +59,12 @@ public class EventFilter : IEventFilter
 
     public void FilterByMinPrice(decimal minPrice)
     {
-        _events = _events.Where(e => e.TicketTypes.All(t => t.Price >= minPrice));
+        _events = _events.Where(e => e.TicketTypes.Any(t => t.Price >= minPrice));
     }
 
     public void FilterByMaxPrice(decimal maxPrice)
     {
-        _events = _events.Where(e => e.TicketTypes.All(t => t.Price <= maxPrice));
+        _events = _events.Where(e => e.TicketTypes.Any(t => t.Price <= maxPrice));
     }
 
     public void FilterByMinAge(uint minAge)
@@ -72,9 +72,9 @@ public class EventFilter : IEventFilter
         _events = _events.Where(e => e.MinimumAge >= minAge);
     }
 
-    public void FilterByMaxAge(uint maxAge)
+    public void FilterByMaxMinimumAge(uint maxMinimumAge)
     {
-        _events = _events.Where(e => e.MinimumAge <= maxAge);
+        _events = _events.Where(e => e.MinimumAge <= maxMinimumAge);
     }
 
     public void FilterByAddressCountry(string country)

--- a/TickAPI/TickAPI/Events/Services/EventFilter.cs
+++ b/TickAPI/TickAPI/Events/Services/EventFilter.cs
@@ -23,7 +23,6 @@ public class EventFilter : IEventFilter
     }
 
     public void FilterByDescription(string description)
-    
     {
         _events = _events.Where(e => e.Description.Contains(description, StringComparison.CurrentCultureIgnoreCase));
     }

--- a/TickAPI/TickAPI/Events/Services/EventFilter.cs
+++ b/TickAPI/TickAPI/Events/Services/EventFilter.cs
@@ -74,4 +74,9 @@ public class EventFilter : IEventFilter
     {
         return events.Where(e => e.Address.PostalCode == postalCode);
     }
+
+    public IQueryable<Event> FilterByCategoriesNames(IQueryable<Event> events, IEnumerable<string> categoriesNames)
+    {
+        return events.Where(e => e.Categories.Any(c => categoriesNames.Contains(c.Name)));
+    }
 }

--- a/TickAPI/TickAPI/Program.cs
+++ b/TickAPI/TickAPI/Program.cs
@@ -92,6 +92,7 @@ builder.Services.AddScoped<ICustomerRepository, CustomerRepository>();
 // Add event services.
 builder.Services.AddScoped<IEventService, EventService>();
 builder.Services.AddScoped<IEventRepository, EventRepository>();
+builder.Services.AddScoped<IEventFilter, EventFilter>();
 
 // Add address services.
 builder.Services.AddScoped<IAddressService, AddressService>();


### PR DESCRIPTION
This PR adds `EventFilter` and is part of #15.
Once #68 and #67 are done it will be added to `EventService` and used in endpoints used for returning events.
The current plan is for `EventService` to include a method that invokes appropriate `EventFilter` functions based on the incoming query parameters.