### PR TITLE
[Fix] Changed EventFilter to not be a service

### DIFF
--- a/TickAPI/TickAPI.Tests/Events/Filters/EventFilterTests.cs
+++ b/TickAPI/TickAPI.Tests/Events/Filters/EventFilterTests.cs
@@ -1,10 +1,10 @@
 ﻿using TickAPI.Addresses.Models;
 using TickAPI.Categories.Models;
+using TickAPI.Events.Filters;
 using TickAPI.Events.Models;
-using TickAPI.Events.Services;
 using TickAPI.TicketTypes.Models;
 
-namespace TickAPI.Tests.Events.Services;
+namespace TickAPI.Tests.Events.Filters;
 
 public class EventFilterTests
 {

--- a/TickAPI/TickAPI/Events/Filters/EventFilter.cs
+++ b/TickAPI/TickAPI/Events/Filters/EventFilter.cs
@@ -1,7 +1,7 @@
 ﻿using TickAPI.Events.Abstractions;
 using TickAPI.Events.Models;
 
-namespace TickAPI.Events.Services;
+namespace TickAPI.Events.Filters;
 
 public class EventFilter : IEventFilter
 {

--- a/TickAPI/TickAPI/Program.cs
+++ b/TickAPI/TickAPI/Program.cs
@@ -92,7 +92,6 @@ builder.Services.AddScoped<ICustomerRepository, CustomerRepository>();
 // Add event services.
 builder.Services.AddScoped<IEventService, EventService>();
 builder.Services.AddScoped<IEventRepository, EventRepository>();
-builder.Services.AddScoped<IEventFilter, EventFilter>();
 
 // Add address services.
 builder.Services.AddScoped<IAddressService, AddressService>();


### PR DESCRIPTION
After making the EventFilter class stateful the former approach of injecting it as a service stops working and therefore the application wouldn't work properly. This PR addresses the issue